### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled command line

### DIFF
--- a/flask_webgoat/actions.py
+++ b/flask_webgoat/actions.py
@@ -40,12 +40,17 @@ def log_entry():
 @bp.route("/grep_processes")
 def grep_processes():
     name = request.args.get("name")
-    # vulnerability: Remote Code Execution
+    if not name.isalnum():
+        return jsonify({"error": "invalid process name"})
     res = subprocess.run(
-        ["ps aux | grep " + name + " | awk '{print $11}'"],
-        shell=True,
+        ["ps", "aux"],
         capture_output=True,
+        text=True,
     )
+    if res.stdout is None:
+        return jsonify({"error": "no stdout returned"})
+    out = res.stdout
+    names = [line.split()[10] for line in out.splitlines() if name in line]
     if res.stdout is None:
         return jsonify({"error": "no stdout returned"})
     out = res.stdout.decode("utf-8")


### PR DESCRIPTION
Potential fix for [https://github.com/soharab-ai/shiftleft-python-demo/security/code-scanning/7](https://github.com/soharab-ai/shiftleft-python-demo/security/code-scanning/7)

To fix the problem, we should avoid constructing shell commands using user input directly. Instead, we can use a predefined allowlist of acceptable process names or use the `subprocess.run` function with a list of arguments to avoid shell interpretation. This will prevent any malicious input from being executed as part of the shell command.

The best way to fix the problem without changing existing functionality is to use the `subprocess.run` function with a list of arguments and avoid using `shell=True`. We can also add a validation step to ensure that the `name` parameter only contains safe characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
